### PR TITLE
Add toggle on/off functionality to plugin

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,10 @@
+[
+	{
+		"caption": "Trailing Spaces: Toggle Trailing Spaces",
+		"command": "toggle_trailing_spaces"
+	},
+	{
+		"caption": "Trailing Spaces: Delete Trailing Spaces",
+		"command": "delete_trailing_spaces"
+	}
+]

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -25,7 +25,9 @@ DEFAULT_COLOR_SCOPE_NAME = "invalid"
 DEFAULT_IS_ENABLED = True
 
 #Set whether the plugin is on or off
-TrailingSpacesEnabled = DEFAULT_IS_ENABLED
+ts_settings = sublime.load_settings('trailing_spaces.sublime-settings')
+trailing_spaces_enabled = bool(ts_settings.get('trailing_spaces_enabled',
+                                               DEFAULT_IS_ENABLED))
 
 
 # Return an array of regions matching trailing spaces.
@@ -35,10 +37,10 @@ def find_trailing_spaces(view):
 
 # Highlight trailing spaces
 def highlight_trailing_spaces(view):
-    max_size = view.settings().get('trailing_spaces_file_max_size',
-                                   DEFAULT_MAX_FILE_SIZE)
-    color_scope_name = view.settings().get('trailing_spaces_highlight_color',
-                                           DEFAULT_COLOR_SCOPE_NAME)
+    max_size = ts_settings.get('trailing_spaces_file_max_size',
+                               DEFAULT_MAX_FILE_SIZE)
+    color_scope_name = ts_settings.get('trailing_spaces_highlight_color',
+                                       DEFAULT_COLOR_SCOPE_NAME)
     if view.size() <= max_size:
         regions = find_trailing_spaces(view)
         view.add_regions('TrailingSpacesHighlightListener',
@@ -55,12 +57,12 @@ def clear_trailing_spaces_highlight(window):
 # Toggle the event listner on or off
 class ToggleTrailingSpacesCommand(sublime_plugin.WindowCommand):
     def run(self):
-        global TrailingSpacesEnabled
-        TrailingSpacesEnabled = False if TrailingSpacesEnabled else True
+        global trailing_spaces_enabled
+        trailing_spaces_enabled = False if trailing_spaces_enabled else True
 
-        # If toggling on go ahead and perform a pass,
-        # if not clear the highlighting in all views
-        if TrailingSpacesEnabled:
+        # If toggling on, go ahead and perform a pass,
+        # else clear the highlighting in all views
+        if trailing_spaces_enabled:
             highlight_trailing_spaces(self.window.active_view())
         else:
             clear_trailing_spaces_highlight(self.window)
@@ -69,15 +71,15 @@ class ToggleTrailingSpacesCommand(sublime_plugin.WindowCommand):
 # Highlight matching regions.
 class TrailingSpacesHighlightListener(sublime_plugin.EventListener):
     def on_modified(self, view):
-        if TrailingSpacesEnabled:
+        if trailing_spaces_enabled:
             highlight_trailing_spaces(view)
 
     def on_activated(self, view):
-        if TrailingSpacesEnabled:
+        if trailing_spaces_enabled:
             highlight_trailing_spaces(view)
 
     def on_load(self, view):
-        if TrailingSpacesEnabled:
+        if trailing_spaces_enabled:
             highlight_trailing_spaces(view)
 
 

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -1,0 +1,10 @@
+{
+	// Color is determined by scope
+	"trailing_spaces_highlight_color" : "invalid",
+
+	// Max file size to search
+	"trailing_spaces_file_max_size"   : 1048576,
+
+	// By default plugin is enabled or disabled (true|false)
+	"trailing_spaces_enabled"         : true
+}


### PR DESCRIPTION
-Add on_load and on_activated to find trailing spaces without being forced to edit file
-Add Command to toggle on/off searching for trailing spaces
-Initiate trailing space search on toggle "on"
-Clear highlights on toggle "off"
-Simplify find_trailing_spaces function
