### PR TITLE
ignore_on_cursor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,12 @@ Highlighting may be disabled for large files. The default threshold is around
 
 Even though the trailing spaces are not highlighted, one can still delete them
 using the deletion command.
+
+### Execute deletion command before saving the file
+
+It could be useful to run the command 'delete_trailing_spaces' automatically before
+saving the file
+
+``` js
+{ "trailing_spaces_delete_on_save": true }
+```

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -23,11 +23,14 @@ import sublime_plugin
 DEFAULT_MAX_FILE_SIZE = 1048576
 DEFAULT_COLOR_SCOPE_NAME = "invalid"
 DEFAULT_IS_ENABLED = True
+DEFAULT_EXECUTE_ON_SAVE = False
 
 #Set whether the plugin is on or off
 ts_settings = sublime.load_settings('trailing_spaces.sublime-settings')
 trailing_spaces_enabled = bool(ts_settings.get('trailing_spaces_enabled',
                                                DEFAULT_IS_ENABLED))
+trailing_spaces_delete_on_save = bool(ts_settings.get('trailing_spaces_delete_on_save',
+                                               DEFAULT_EXECUTE_ON_SAVE))
 
 # Determine if the view is a find results view
 def is_find_results(view):
@@ -96,6 +99,10 @@ class TrailingSpacesHighlightListener(sublime_plugin.EventListener):
     def on_load(self, view):
         if trailing_spaces_enabled:
             highlight_trailing_spaces(view)
+
+    def on_pre_save(self, view):
+        if trailing_spaces_delete_on_save:
+            view.run_command('delete_trailing_spaces')
 
 
 # Allows to erase matching regions.

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -12,5 +12,8 @@
 	"trailing_spaces_include_empty_lines" : true,
 
 	// Do not highlight trailing spaces, if they are next to cursor
-	"ignore_on_cursor" : true
+	"ignore_on_cursor" : true,
+
+	// By default, delete trailing spaces on save
+	"trailing_spaces_delete_on_save": true
 }


### PR DESCRIPTION
I have found that highlighted spaces you just typed is pretty annoying. Also, this effect appears cause of automatic identation of the sublime text.

So, i added the option to fix this behavior.
