### PR TITLE
Fix "inlude" typo in settings fetch.

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -39,7 +39,7 @@ def find_trailing_spaces(view):
     line = view.line(sel.b)
     include_empty_lines = bool(ts_settings.get('trailing_spaces_include_empty_lines',
                                                DEFAULT_IS_ENABLED))
-    include_current_line = bool(ts_settings.get('trailing_spaces_inlude_current_line',
+    include_current_line = bool(ts_settings.get('trailing_spaces_include_current_line',
                                                 DEFAULT_IS_ENABLED))
     offending_lines = view.find_all('[ \t]+$' if include_empty_lines else '(?<=\S)[\t ]+$')
     if include_current_line:

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -12,5 +12,5 @@
 	"trailing_spaces_include_empty_lines" : true,
 
 	// By default the line being currently edited will not report trailing whitespace
-	"trailing_spaces_inlude_current_line" : true
+	"trailing_spaces_include_current_line" : true
 }


### PR DESCRIPTION
README.md was updated for the correct spelling, but the underlying code was still using the incorrect spelling of "include".
