### PR TITLE
Sublime Text 3 support

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -58,8 +58,7 @@ def highlight_trailing_spaces(view):
     if view.size() <= max_size and not is_find_results(view):
         regions = find_trailing_spaces(view)
         view.add_regions('TrailingSpacesHighlightListener',
-                         regions, color_scope_name,
-                         sublime.DRAW_EMPTY)
+                         regions, color_scope_name)
 
 
 # Clear all trailing spaces


### PR DESCRIPTION
This pr changes one line and makes this plugin work in sublime text 3
sublime.DRAW_EMPTY wasn't needed as the default value of _icon_ is none
