### PR TITLE
Proposed fix for crash on first load

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -16,6 +16,7 @@ import codecs
 DEFAULT_MAX_FILE_SIZE = 1048576
 DEFAULT_IS_ENABLED = True
 DEFAULT_MODIFIED_LINES_ONLY = False
+DEFAULT_REGEXP = "[ \t]+"
 
 # Global settings object and flags.
 # Flags duplicate some of the (core) JSON settings, in case the settings file has
@@ -87,7 +88,7 @@ def find_trailing_spaces(view):
                                                DEFAULT_IS_ENABLED))
     include_current_line = bool(ts_settings.get("trailing_spaces_include_current_line",
                                                 DEFAULT_IS_ENABLED))
-    regexp = ts_settings.get("trailing_spaces_regexp") + "$"
+    regexp = ts_settings.get("trailing_spaces_regexp", DEFAULT_REGEXP) + "$"
     no_empty_lines_regexp = "(?<=\S)%s$" % regexp
 
     offending_lines = view.find_all(regexp if include_empty_lines else no_empty_lines_regexp)


### PR DESCRIPTION
Fixes SublimeText/TrailingSpaces/issues/38, SublimeText/TrailingSpaces/issues/41, SublimeText/TrailingSpaces/issues/54 and SublimeText/TrailingSpaces/issues/58.

This employs the same technique used by other default values, defining a `DEFAULT_REGEXP` and utilising that as the default.

It appears that the `plugin_loaded` call can occur before the `trailing_spaces.sublime-settings` file is copied into the plugin directory, meaning that Sublime loads an empty settings object.

You can reproduce this behaviour by removing the plug in, and then manually copying the settings file into the folder before copying the plugin's python file. If performed in this order, the settings load correctly.

This patch has only been tested in Sublime Text 2, however, it uses techniques which are already used throughout the plug-in and work just fine in ST3.

If this is not satisfactory, it may be possible to rename `trailing_spaces.sublime-settings` to a file name which occurs "before" `trailing_spaces.py`, to change the order in which the files are written to disk, however this would have the disadvantage of invalidating all users' existing preferences.
