### PR TITLE
Prevent highlighting in build results view

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -119,10 +119,20 @@ def match_trailing_spaces(view):
     if max_size_exceeded(view):
         return
 
-    if not is_find_results(view):
-        (matched, highlightable) = find_trailing_spaces(view)
-        add_trailing_spaces_regions(view, matched)
-        highlight_trailing_spaces_regions(view, highlightable)
+    # Only run in the active view. This avoids running in build results view.
+    if not view.window():
+        return
+
+    if view != view.window().active_view():
+        return
+
+    # Avoid running in find results view
+    if is_find_results(view):
+        return
+
+    (matched, highlightable) = find_trailing_spaces(view)
+    add_trailing_spaces_regions(view, matched)
+    highlight_trailing_spaces_regions(view, highlightable)
 
 
 # Private: Checks whether the document is bigger than the max_size setting.


### PR DESCRIPTION
This PR solves issue #10.

It works by allowing highlighting only in the active view, as suggested by FichteFoll. This excludes the build results view.
