### PR TITLE
Escape unintended bullet point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Options
 Several options are available to customize the plugin's behavior. Those
 settings are stored in a configuration file, as JSON. You must use a specific
 file: Go to "Preferences / Package Settings / Trailing Spaces / Settings
-- User" to add you custom settings. You can look at the default values in
+\- User" to add you custom settings. You can look at the default values in
 "Settings - Default", in the same menu.
 
 A few of them are also accessible through the "Edit / Trailing Spaces" menu.


### PR DESCRIPTION
The 'Options' section contains a random bullet point due to a hyphen character at the beginning of a line.

This patch (probably the most simple ever submitted!) escapes the character :)
