### PR TITLE
Add settings comment for how to make highlight invisible

### DIFF
--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -14,7 +14,8 @@
     "trailing_spaces_enabled" : true,
 
     // Highlight color is specified as a scope. You may define and use a custom
-    // scope to better fit your colorscheme.
+    // scope to better fit your colorscheme. A value of empty string "" will
+    // make highlights invisible.
     "trailing_spaces_highlight_color" : "invalid",
 
     // By default, empty lines are cleared as well when calling the deletion


### PR DESCRIPTION
I know this is already in the wiki but every time I install this plugin but I have to Google for how to make highlights invisible. It's such a simple change to describe that I think it should really be in the preference comments.