### PR TITLE
Fix exception thrown on activating views with 'virtual' path #85

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -433,10 +433,12 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
     def freeze_last_version(self, view):
         global on_disk
 
+        # There are views with no associated path like scratch views created by
+        # plugins or newly created, but not yet saved views. Also, even if the
+        # view has a path, it might not be a real path. That's the case for
+        # files read from packages using sublime.load_resource() API.
         file_name = view.file_name()
-        # For some reasons, the on_activated hook gets fired on a ghost document
-        # from time to time.
-        if file_name:
+        if file_name and os.path.isfile(file_name):
             on_disk = codecs.open(file_name, "r", "utf-8").read().splitlines()
 
 


### PR DESCRIPTION
Fixes those errors:

Traceback (most recent call last):
  File "C:\Users________\Sublime Text\sublime_plugin.py", line 240, in on_pre_save
    callback.on_pre_save(v)
  File "trailing_spaces in C:\Users________\Sublime Text\Data\Installed Packages\TrailingSpaces.sublime-package", line 424, in on_pre_save
  File "trailing_spaces in C:\Users________\Sublime Text\Data\Installed Packages\TrailingSpaces.sublime-package", line 440, in freeze_last_version
  File "./codecs.py", line 885, in open
