### PR TITLE
Update install.txt

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -5,10 +5,6 @@
 
     You're now ready to give trailing spaces *a hard time*!
 
-    Wait… I guess Package Control just introduced some of them :(
-    Why don't you try clicking "Edit / Trailing Spaces / Delete"?
-
-
 
 Documentation
 =============


### PR DESCRIPTION
Package Control messages are now read-only, so there's no point in leaving this part of the message.