### PR TITLE
New config option: `trailing_spaces_scope_ignore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,16 +278,22 @@ a binding for the toggling command. When "On-demand Matching" is on and some
 trailing spaces are highlighted, added ones will obviously not be. Toggling
 highlight off and on will refresh them.
 
-### Ignore Syntax
+### Ignore Scope
 
-*Default: []*
+*Default: ["text.find-in-files", "source.build_output"]*
 
-With this option you can ignore specific files/views based on the syntax used.
-An item has to match a case-sensitive substring of the syntax used in the view:
+With this option you can ignore lines being highlighted based on the scope of
+their trailing region.
+
+If at least one scope in the configured list must match a scope in the trailing
+region of the line, it won't be highlighted.
+
+By default, the scope under the mouse cursor is shown by pressing
+`Super+Alt+P` (OS X) or `Ctrl+Alt+Shift+P` (Windows, Linux)
 
 ``` js
-// Views with a syntax that contains "Diff" are ignored
-{ "trailing_spaces_syntax_ignore": ["Diff"]}
+// Trailing spaces for find results, build output and markdown are ignored
+{ "trailing_spaces_scope_ignore": ["text.find-in-files", "source.build_output", "text.html.markdown"] }
 ```
 
 ### For power-users only!

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ highlight off and on will refresh them.
 With this option you can ignore lines being highlighted based on the scope of
 their trailing region.
 
-If at least one scope in the configured list must match a scope in the trailing
+If at least one scope in the configured list matches a scope in the trailing
 region of the line, it won't be highlighted.
 
 By default, the scope under the mouse cursor is shown by pressing

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -28,6 +28,10 @@
     // Set to false to ignore trailing spaces on the edited line.
     "trailing_spaces_include_current_line" : true,
 
+    // By default, any lines in the Find Results and Build output are ignored
+    // Add/remove scopes in this list if you need to ignore other scopes.
+    "trailing_spaces_scope_ignore": ["text.find-in-files", "source.build_output"],
+
     // By default, trailing spaces are deleted within the whole document.
     // Set to true to affect only the lines you edited since last save.
     // Trailing spaces will still be searched for and highlighted in the whole

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -29,7 +29,7 @@
     "trailing_spaces_include_current_line" : true,
 
     // By default, any lines in the Find Results and Build output are ignored
-    // Add/remove scopes in this list if you need to ignore other scopes.
+    // Add scopes to this list if you need to ignore them.
     "trailing_spaces_scope_ignore": ["text.find-in-files", "source.build_output"],
 
     // By default, trailing spaces are deleted within the whole document.


### PR DESCRIPTION
Also, remove mentions of the inferior `trailing_spaces_syntax_ignore` option in the README (still considered in the code for backward compat).

Default value:
```js
// Trailing spaces for find results and build output are ignored
"trailing_spaces_scope_ignore": ["text.find-in-files", "source.build_output"]
```

This PR supersedes #98 (which I will now close).

*This is a more flexible variation of the syntax ignore setting, as it provides fine-grained control over the ignored matches.*