### PR TITLE
Improve character encoding compatibility

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -437,7 +437,17 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
         # For some reasons, the on_activated hook gets fired on a ghost document
         # from time to time.
         if file_name:
-            on_disk = codecs.open(file_name, "r", "utf-8").read().splitlines()
+            # This is the default "fallback_encoding" for Sublime Text
+            # UTF-8 files without a BOM will otherwise default to this
+            if view.encoding() == "Western (Windows 1252)":
+                encoding = "windows-1252"
+            else:
+                encoding = "utf-8"
+
+            try:
+                on_disk = codecs.open(file_name, "r", encoding).read().splitlines()
+            except UnicodeDecodeError as e:
+                sublime.status_message("Invalid characters in {0}: {1}".format(file_name, e))
 
 
 # Public: Deletes the trailing spaces.


### PR DESCRIPTION
This pull request fixes issue #48.

Trailing Spaces assumes all files are UTF-8 encoded, which can lead to errors in the console. This pull request changes this behaviour, the character encoding that Sublime Text is aware of will be used instead when opening files.

If a file without a BOM is opened, Sublime Text will default to the Windows 1252 character set if it is compatible:

`unable to auto detect encoding for ~/Desktop/test.txt, using fallback encoding Western (Windows 1252)`

If a file containing valid Windows 1252 characters, but invalid UTF-8 bytes (for example a file containing `f4 0a`) the following error would appear in the console:

`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf4 in position 0: invalid continuation byte`