### PR TITLE
Proposed fix for exception while processing scratch buffers

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -436,7 +436,7 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
         file_name = view.file_name()
         # For some reasons, the on_activated hook gets fired on a ghost document
         # from time to time.
-        if file_name:
+        if file_name and not view.is_scratch():
             on_disk = codecs.open(file_name, "r", "utf-8").read().splitlines()
 
 


### PR DESCRIPTION
Unable to open /C/Users/.../st/Data/Packages/REG/REG.sublime-settings
Traceback (most recent call last):
  File "C:\Users\...\st\sublime_plugin.py", line 389, in run_callback
    expr()
  File "C:\Users\...\st\sublime_plugin.py", line 522, in <lambda>
    run_callback('on_activated', callback, lambda: callback.on_activated(v))
  File "trailing_spaces in C:\Users\...\st\Data\Installed Packages\TrailingSpaces.sublime-package", line 419, in on_activated
  File "trailing_spaces in C:\Users\...\st\Data\Installed Packages\TrailingSpaces.sublime-package", line 440, in freeze_last_version
  File "./python3.3/codecs.py", line 896, in open
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\...\\st\\Data\\Packages\\REG\\REG.sublime-settings'