### PR TITLE
Speedup matching

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -464,18 +464,15 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
         if trim_modified_lines_only:
             self.freeze_last_version(view)
 
-        # track
-        active_views[view.id()] = view.visible_region()
-
         if trailing_spaces_live_matching:
             match_trailing_spaces(view)
 
             # continuously watch view for changes to the visible region
-            self.update_view_on_scroll(view)
+            if not view.id() in active_views:
+                # track
+                active_views[view.id()] = view.visible_region()
 
-    def on_deactivated(self, view):
-        # untrack
-        active_views.pop(view.id(), None)
+                self.update_view_on_scroll(view)
 
     def on_pre_save(self, view):
         global trim_modified_lines_only

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -482,6 +482,10 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
         if ts_settings.get("trailing_spaces_trim_on_save"):
             view.run_command("delete_trailing_spaces")
 
+    def on_close(self, view):
+        # untrack
+        active_views.pop(view.id(), None)
+
     def update_view_on_scroll(self, view):
         # compare the currently visible region to the previous (if any) and
         # update if there were changes

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -487,6 +487,12 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
         active_views.pop(view.id(), None)
 
     def update_view_on_scroll(self, view):
+        # panel views don't trigger on_close but are also not valid anymore
+        # after being hidden, so try to detect these cases here
+        if view.size() == 0 and not view.file_name():
+            active_views.pop(view.id(), None)
+            return
+
         # compare the currently visible region to the previous (if any) and
         # update if there were changes
         if view.visible_region() != active_views.get(view.id(), view.visible_region()):

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -18,6 +18,7 @@ from os.path import isfile
 
 DEFAULT_MAX_FILE_SIZE = 1048576
 DEFAULT_IS_ENABLED = True
+DEFAULT_NON_VISIBLE_HIGHLIGHTING = 500
 DEFAULT_UPDATE_INTERVAL = 250
 DEFAULT_MODIFIED_LINES_ONLY = False
 
@@ -27,6 +28,7 @@ DEFAULT_MODIFIED_LINES_ONLY = False
 ts_settings_filename = "trailing_spaces.sublime-settings"
 ts_settings = None
 trailing_spaces_live_matching = DEFAULT_IS_ENABLED
+trailing_spaces_non_visible_highlighting = DEFAULT_NON_VISIBLE_HIGHLIGHTING
 trailing_spaces_update_interval = DEFAULT_UPDATE_INTERVAL
 trim_modified_lines_only = DEFAULT_MODIFIED_LINES_ONLY
 trailing_spaces_syntax_ignore = []
@@ -42,13 +44,15 @@ active_views = {}
 # Returns nothing.
 def plugin_loaded():
     global ts_settings_filename, ts_settings, trailing_spaces_live_matching
-    global trailing_spaces_update_interval
+    global trailing_spaces_non_visible_highlighting, trailing_spaces_update_interval
     global current_highlighting_scope, trim_modified_lines_only, startup_queue
     global DEFAULT_COLOR_SCOPE_NAME, trailing_spaces_syntax_ignore
 
     ts_settings = sublime.load_settings(ts_settings_filename)
     trailing_spaces_live_matching = bool(ts_settings.get("trailing_spaces_enabled",
                                          DEFAULT_IS_ENABLED))
+    trailing_spaces_non_visible_highlighting = int(ts_settings.get("trailing_spaces_non_visible_highlighting",
+                                                   DEFAULT_UPDATE_INTERVAL))
     trailing_spaces_update_interval = int(ts_settings.get("trailing_spaces_update_interval",
                                           DEFAULT_UPDATE_INTERVAL))
     current_highlighting_scope = ts_settings.get("trailing_spaces_highlight_color",
@@ -118,8 +122,15 @@ def find_trailing_spaces(view):
     if not include_empty_lines:
         regexp = "(?<=\\S)%s$" % regexp
 
-    # find all matches in the currently visible region
-    offending_lines = view_find_all_in_region(view, view.visible_region(), regexp)
+    # find all matches in the currently visible region plus a little before and
+    # after
+    searched_region = view.visible_region()
+    searched_region.a = max(searched_region.a - trailing_spaces_non_visible_highlighting, 0);
+    searched_region.b = min(searched_region.b + trailing_spaces_non_visible_highlighting, view.size());
+
+    searched_region = view.line(searched_region)  # align to line start and end
+    offending_lines = view_find_all_in_region(view, searched_region, regexp)
+
     ignored_scopes = ",".join(ts_settings.get("trailing_spaces_scope_ignore", []))
     filtered_lines = []
     for region in offending_lines:

--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -501,7 +501,8 @@ class TrailingSpacesListener(sublime_plugin.EventListener):
 
         # continue only if the view is still active
         if trailing_spaces_live_matching and view.id() in active_views:
-            sublime.set_timeout(lambda: self.update_view_on_scroll(view), trailing_spaces_update_interval)
+            sublime.set_timeout_async(lambda: self.update_view_on_scroll(view),
+                                      trailing_spaces_update_interval)
 
     # Toggling messes with what is red from the disk, and it breaks the diff
     # used when modified_lines_only is true. Honestly, I don't know why (yet).

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -47,6 +47,13 @@
 
     // ---- NEXT SETTINGS ARE FOR POWER USERS ONLY! ----
 
+    // The number of characters before and after the visible region of text to
+    // include in the highlighting. This is useful to also show the highlighting
+    // immediately for text that just became visible through scrolling.
+    // Adjust the value (in the number of characters) to whatever fits your
+    // needs and performance.
+    "trailing_spaces_non_visible_highlighting" : 500,
+
     // This is the interval at which the active view is tested for changes
     // (due to scrolling) to update the highlighting of the currently visible
     // region of text.

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -47,6 +47,13 @@
 
     // ---- NEXT SETTINGS ARE FOR POWER USERS ONLY! ----
 
+    // This is the interval at which the active view is tested for changes
+    // (due to scrolling) to update the highlighting of the currently visible
+    // region of text.
+    // Adjust the value (in milliseconds) to whatever fits your needs and
+    // performance.
+    "trailing_spaces_update_interval" : 250,
+
     // Highlighting will be disabled if the edited file's size is larger than
     // this.
     // Adjust the value (in number of chars) to whatever fits your performance.


### PR DESCRIPTION
Currently live matching will always search through the whole file which can be very slow for large files and more complex regex patterns.

With this change it will only search through the currently visible region of text.