### PR TITLE
Use region.redish to highlight trailing spaces

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -43,7 +43,7 @@ def plugin_loaded():
     trailing_spaces_live_matching = bool(ts_settings.get("trailing_spaces_enabled",
                                          DEFAULT_IS_ENABLED))
     current_highlighting_scope = ts_settings.get("trailing_spaces_highlight_color",
-                                                 "invalid")
+                                                 "region.redish")
     DEFAULT_COLOR_SCOPE_NAME = current_highlighting_scope
     trim_modified_lines_only = bool(ts_settings.get("trailing_spaces_modified_lines_only",
                                                     DEFAULT_MODIFIED_LINES_ONLY))

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -12,7 +12,7 @@
     // Highlight color is specified as a scope. You may define and use a custom
     // scope to better fit your colorscheme. A value of empty string "" will
     // make highlights invisible.
-    "trailing_spaces_highlight_color" : "invalid",
+    "trailing_spaces_highlight_color" : "region.redish",
 
     // By default, empty lines are cleared as well when calling the deletion
     // command.


### PR DESCRIPTION
That color is better for the use case as it's gonna have a reliable
red color. `invalid` scope can look like anything, depending on syntax
and what not.

With this change the package will officially switch to only supporting ST3+.

Resolves #125