### PR TITLE
Ignore scratch views

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -136,6 +136,9 @@ def match_trailing_spaces(view):
 #
 # Returns True if the view should be ignored, False otherwise.
 def ignore_view(view):
+    if view.is_scratch():
+        return True
+
     view_syntax = view.settings().get('syntax')
 
     if not view_syntax:


### PR DESCRIPTION
Main reason for that is Terminus plugin that uses plain.text scope and
syntax so can't be ignored through those means.

But this change should make sense in general, anyway.

Resolves #127