### PR TITLE
Run async versions of all listeners

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -441,15 +441,15 @@ class ToggleTrailingSpacesModifiedLinesOnlyCommand(sublime_plugin.WindowCommand)
 # Public: Matches and highlights trailing spaces on key events, according to the
 # current settings.
 class TrailingSpacesListener(sublime_plugin.EventListener):
-    def on_modified(self, view):
+    def on_modified_async(self, view):
         if trailing_spaces_live_matching:
             match_trailing_spaces(view)
 
-    def on_selection_modified(self, view):
+    def on_selection_modified_async(self, view):
         if trailing_spaces_live_matching:
             match_trailing_spaces(view)
 
-    def on_activated(self, view):
+    def on_activated_async(self, view):
         global trim_modified_lines_only
         if trim_modified_lines_only:
             self.freeze_last_version(view)


### PR DESCRIPTION
Matching trailing space was done synchronously on file modification,
activation, and cursor movements but asynchronously after that from
an interval. Now we do matching asynchronously in all cases.