### PR TITLE
Add Markdown to "scope_ignore" default setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ highlight off and on will refresh them.
 
 ### Ignore Scope
 
-*Default: ["text.find-in-files", "source.build_output", "source.diff"]*
+*Default: ["text.find-in-files", "source.build_output", "source.diff", "text.html.markdown"]*
 
 With this option you can ignore lines being highlighted based on the scope of
 their trailing region.
@@ -290,8 +290,8 @@ By default, the scope under the mouse cursor is shown by pressing
 `Option+Command+P` (OS X) or `Ctrl+Alt+Shift+P` (Windows, Linux)
 
 ``` js
-// Trailing spaces for find results, build output and markdown are ignored
-{ "scope_ignore": ["text.find-in-files", "source.build_output", "text.html.markdown"] }
+// Trailing spaces for Find Results, Build output, Diff and Markdown are ignored
+{ "scope_ignore": ["text.find-in-files", "source.build_output", "source.diff", "text.html.markdown"] }
 ```
 
 ### For power-users only!

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -24,7 +24,7 @@
     // Set to false to ignore trailing spaces on the edited line.
     "include_current_line" : true,
 
-    // By default, any lines in the Find Results, Build output, Diff and markdown views are ignored
+    // By default, any lines in the Find Results, Build output, Diff and Markdown views are ignored
     // Add scopes to this list if you need to ignore them.
     "scope_ignore": ["text.find-in-files", "source.build_output", "source.diff", "text.html.markdown"],
 

--- a/trailing_spaces.sublime-settings
+++ b/trailing_spaces.sublime-settings
@@ -24,9 +24,9 @@
     // Set to false to ignore trailing spaces on the edited line.
     "include_current_line" : true,
 
-    // By default, any lines in the Find Results Build output and Diff views are ignored
+    // By default, any lines in the Find Results, Build output, Diff and markdown views are ignored
     // Add scopes to this list if you need to ignore them.
-    "scope_ignore": ["text.find-in-files", "source.build_output", "source.diff"],
+    "scope_ignore": ["text.find-in-files", "source.build_output", "source.diff", "text.html.markdown"],
 
     // By default, trailing spaces are deleted within the whole document.
     // Set to true to affect only the lines you edited since last save.


### PR DESCRIPTION
This PR adds Markdown to the "scope_ignore" default setting.
The reason is because trimming trailing spaces changes the output of the Markdown (2 trailing spaces means `<br>`).

Also, for reference, currently, in README.me the "scope_ignore" reference has:

```json
// Trailing spaces for find results, build output and markdown are ignored
{ "scope_ignore": ["text.find-in-files", "source.build_output", "text.html.markdown"] }
```

while in the actual `trailing_spaces.sublime-settings` file currently is:

```json
// By default, any lines in the Find Results Build output and Diff views are ignored
// Add scopes to this list if you need to ignore them.
"scope_ignore": ["text.find-in-files", "source.build_output", "source.diff"],
```