### PR TITLE
Add None check for single line files

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -256,6 +256,8 @@ def clear_trailing_spaces_highlight(window):
 #
 # Returns the list of edited line numbers.
 def modified_lines_as_numbers(old, new):
+    if old is None:
+        old = []
     d = difflib.Differ()
     diffs = d.compare(old, new)
 


### PR DESCRIPTION
This pull request checks if the `old` value is `None` and sets it to `[]`, which prevents the following error:
"TypeError: object of type 'NoneType' has no len()"

The issue can be reproduced by entering the following text and saving:
"a 
"