### PR TITLE
Add None check to prevent 'NoneType' has no len() error

### DIFF
--- a/trailing_spaces.py
+++ b/trailing_spaces.py
@@ -285,7 +285,7 @@ def modified_lines_as_numbers(old, new):
 def get_modified_lines(view):
     on_buffer = view.substr(sublime.Region(0, view.size())).splitlines()
     lines = []
-    line_numbers = modified_lines_as_numbers(on_disk, on_buffer)
+    line_numbers = modified_lines_as_numbers(on_disk or [], on_buffer)
     if line_numbers:
         lines = [view.full_line(view.text_point(number, 0)) for number in line_numbers]
     return lines


### PR DESCRIPTION
This pull request defaults to `[]` if the value of `on_disk` is `None`, which can prevent trailing spaces being removed from the top line.

The issue can be reproduced by entering the following text and saving:
"a 
"